### PR TITLE
Avoid crash then gzip-decompressing empty body

### DIFF
--- a/lib/tesla/middleware/compression.ex
+++ b/lib/tesla/middleware/compression.ex
@@ -84,6 +84,10 @@ defmodule Tesla.Middleware.Compression do
     Tesla.put_header(env, "content-encoding", Enum.join(unknown_codecs, ", "))
   end
 
+  defp decompress_body(_codecs, "" = body, acc) do
+    {body, acc}
+  end
+
   defp decompress_body([gzip | rest], body, acc) when gzip in ["gzip", "x-gzip"] do
     decompress_body(rest, :zlib.gunzip(body), acc)
   end


### PR DESCRIPTION
When doing a HEAD-request with `"Accept-Encoding: gzip"`, some web servers set the `content-encoding` to `gzip`, but naturally transfer an empty body.

This makes `:zlib.gunzip` crash with

```
** (ErlangError) Erlang error: :data_error
    (erts 15.2.7) :zlib.inflateEnd_nif(#Reference<0.2948451012.2698379265.82762>)
    (erts 15.2.7) :zlib.gunzip/1
    iex:1: (file)
```

This PR skips decompression of an empty `body`.